### PR TITLE
scalatest: 3.2.16 -> 3.2.17

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ scalacOptions ++= Seq( "-deprecation"
 sbtPlugin := true
 enablePlugins(SbtPlugin)
 libraryDependencies += "com.vladsch.flexmark" % "flexmark-all" % "0.62.2"
-libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.16" % "test"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.17" % "test"
 
 // scripted-plugin
 scriptedBufferLog := false


### PR DESCRIPTION
📦 Updates [org.scalatest:scalatest](https://github.com/scalatest/scalatest) from `3.2.16` to `3.2.17`