### PR TITLE
scalatest: 3.2.17 -> 3.2.18

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ scalacOptions ++= Seq( "-deprecation"
 sbtPlugin := true
 enablePlugins(SbtPlugin)
 libraryDependencies += "com.vladsch.flexmark" % "flexmark-all" % "0.62.2"
-libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.17" % "test"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.18" % "test"
 
 // scripted-plugin
 scriptedBufferLog := false


### PR DESCRIPTION
📦 Updates [org.scalatest:scalatest](https://github.com/scalatest/scalatest) from `3.2.17` to `3.2.18`

📜 [GitHub Release Notes](https://github.com/scalatest/scalatest/releases/tag/release-3.2.18) - [Version Diff](https://github.com/scalatest/scalatest/compare/release-3.2.17...release-3.2.18)