### PR TITLE
flexmark-all: 0.62.2 -> 0.64.8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ scalacOptions ++= Seq( "-deprecation"
                      )
 sbtPlugin := true
 enablePlugins(SbtPlugin)
-libraryDependencies += "com.vladsch.flexmark" % "flexmark-all" % "0.62.2"
+libraryDependencies += "com.vladsch.flexmark" % "flexmark-all" % "0.64.8"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.19" % "test"
 
 // scripted-plugin


### PR DESCRIPTION
📦 Updates [com.vladsch.flexmark:flexmark-all](https://github.com/vsch/flexmark-java) from `0.62.2` to `0.64.8`